### PR TITLE
Add dep_protoc_gen_connect_go Makefile

### DIFF
--- a/make/go/dep_protoc_gen_connect_go.mk
+++ b/make/go/dep_protoc_gen_connect_go.mk
@@ -1,7 +1,8 @@
+# Managed by makego. DO NOT EDIT.
+
 # Must be set
 $(call _assert_var,MAKEGO)
 $(call _conditional_include,$(MAKEGO)/base.mk)
-$(call _conditional_include,make/go/base.mk)
 $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 

--- a/make/go/dep_protoc_gen_connect_go.mk
+++ b/make/go/dep_protoc_gen_connect_go.mk
@@ -1,0 +1,20 @@
+# Must be set
+$(call _assert_var,MAKEGO)
+$(call _conditional_include,$(MAKEGO)/base.mk)
+$(call _conditional_include,make/go/base.mk)
+$(call _assert_var,CACHE_VERSIONS)
+$(call _assert_var,CACHE_BIN)
+
+# Settable
+# https://github.com/bufbuild/connect-go 20220512 checked 20220513
+CONNECT_VERSION ?= c35ee255c4f0265262da15a5f431d761a7498b93
+
+PROTOC_GEN_CONNECT_GO := $(CACHE_VERSIONS)/connect-go/$(CONNECT_VERSION)
+$(PROTOC_GEN_CONNECT_GO):
+	@rm -f $(CACHE_BIN)/connect-go
+	GOBIN=$(CACHE_BIN) go install github.com/bufbuild/connect-go/cmd/protoc-gen-connect-go@$(CONNECT_VERSION)
+	@rm -rf $(dir $(PROTOC_GEN_CONNECT_GO))
+	@mkdir -p $(dir $(PROTOC_GEN_CONNECT_GO))
+	@touch $(PROTOC_GEN_CONNECT_GO)
+
+dockerdeps:: $(PROTOC_GEN_CONNECT_GO)


### PR DESCRIPTION
This adds the dep_protoc_gen_connect_go to `makego` so that it can be copied over to dependent repos.

Tested locally that it passes `make`:
```
bash make/go/scripts/checknodiffgenerated.bash make generate
make[5]: Nothing to be done for `preinstallgenerate'.
make bufgeneratedeps
make[6]: Nothing to be done for `bufgeneratedeps'.
buf format -w .
make bufgenerateclean
rm -rf internal/gen/proto
make bufgeneratesteps
buf generate
make[5]: Nothing to be done for `prepostgenerate'.
make[5]: Nothing to be done for `postprepostgenerate'.
gofmt -s -w ALL_GO_FILES
go mod tidy -v
git-ls-files-unstaged | \
                grep -v -e \/testdata | \
                xargs license-header \
                        --license-type "apache" \
                        --copyright-holder "Buf Technologies, Inc." \
                        --year-range "2020-2022"
golangci-lint run --timeout 3m0s
buf lint .
WARN [linters context] bodyclose is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] contextcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] gosimple is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] nilerr is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] rowserrcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] staticcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] structcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] stylecheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] wastedassign is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] unused is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
go test -test.short  ./cmd/... ./internal/...
?       github.com/bufbuild/makego/cmd/foo      [no test files]
ok      github.com/bufbuild/makego/internal/foo (cached)
?       github.com/bufbuild/makego/internal/gen/proto/go/org/foo/v1     [no test files]
```