### PR TITLE
Upgrade golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,6 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
-    - deadcode
     - decorder
     - depguard
     - dogsled
@@ -37,6 +36,8 @@ linters:
     - grouper
     - importas
     - ineffassign
+    - interfacebloat
+    - logrlint
     - makezero
     - misspell
     - nakedret
@@ -45,14 +46,13 @@ linters:
     - nosprintfhostport
     - predeclared
     - promlinter
+    - reassign
     - rowserrcheck
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - wastedassign
     - whitespace
   disable-all: true

--- a/make/go/dep_golangci_lint.mk
+++ b/make/go/dep_golangci_lint.mk
@@ -7,9 +7,9 @@ $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://github.com/golangci/golangci-lint/releases 20220804 checked 20220808
+# https://github.com/golangci/golangci-lint/releases 20220824 checked 20220920
 # Check for new linters and add to .golangci.yml (even if commented out) when upgrading
-GOLANGCI_LINT_VERSION ?= v1.48.0
+GOLANGCI_LINT_VERSION ?= v1.49.0
 
 GOLANGCI_LINT := $(CACHE_VERSIONS)/golangci-lint/$(GOLANGCI_LINT_VERSION)
 $(GOLANGCI_LINT):


### PR DESCRIPTION
See changelog in https://github.com/golangci/golangci-lint/releases/tag/v1.49.0 for changes to the linter list.