### PR TITLE
revert protoc upgrade

### DIFF
--- a/make/go/dep_protoc.mk
+++ b/make/go/dep_protoc.mk
@@ -10,8 +10,9 @@ $(call _assert_var,CACHE_INCLUDE)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://github.com/protocolbuffers/protobuf/releases 20221214 checked 20230104
-PROTOC_VERSION ?= 21.12
+# https://github.com/protocolbuffers/protobuf/releases 20220929 checked 20230104
+# NOTE: Set to version compatible with genproto source code (only used in tests).
+PROTOC_VERSION ?= 21.7
 
 ifeq ($(UNAME_OS),Darwin)
 PROTOC_OS := osx


### PR DESCRIPTION
This dependency is only used in Buf CLI tests and is currently failing because we are generating code with a newer protoc than the genproto sources.