### PR TITLE
Add CACHE_DOCKER variable

### DIFF
--- a/make/go/base.mk
+++ b/make/go/base.mk
@@ -32,6 +32,7 @@ CACHE_BASE ?= $(HOME)/.cache/$(PROJECT)
 
 CACHE := $(CACHE_BASE)/$(UNAME_OS)/$(UNAME_ARCH)
 CACHE_BIN := $(CACHE)/bin
+CACHE_DOCKER := $(CACHE)/docker
 CACHE_INCLUDE := $(CACHE)/include
 CACHE_VERSIONS := $(CACHE)/versions
 CACHE_ENV := $(CACHE)/env


### PR DESCRIPTION
Update makego to add a CACHE_DOCKER variable (this is used in some downstream projects to support using a pull through cache for Docker images).