### PR TITLE
Check if .git exists as a file as well

### DIFF
--- a/make/go/base.mk
+++ b/make/go/base.mk
@@ -193,7 +193,7 @@ generate: ## Run all generation steps.
 
 .PHONY: checknodiffgenerated
 checknodiffgenerated:
-	@ if [ -d .git ]; then \
+	@ if [[ -d .git || -f .git ]]; then \
 			$(MAKE) __checknodiffgeneratedinternal; \
 		else \
 			echo "skipping make checknodiffgenerated due to no .git repository" >&2; \


### PR DESCRIPTION
If the directory you are working from is a git worktree, `.git` [is not a directory but a file](https://git-scm.com/docs/git-worktree#_details)(last sentence of the second paragraph).

This fixes getting `skipping make checknodiffgenerated due to no .git repository` when running make from a git worktree.