### PR TITLE
Bump golangci-lint to v1.55.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,7 @@ linters:
     - govet
     - grouper
     - importas
+    - inamedparam
     - ineffassign
     - interfacebloat
     - logrlint
@@ -46,12 +47,15 @@ linters:
     - nilerr
     - nolintlint
     - nosprintfhostport
+    - perfsprint
     - predeclared
     - promlinter
+    - protogetter
     - reassign
     - rowserrcheck
     - staticcheck
     - stylecheck
+    - testifylint
     - typecheck
     - unconvert
     - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
   disable:
     - cyclop            # covered by gocyclo
     - deadcode          # abandoned
+    - depguard          # newer versions require explicit config to depend on anything outside of the Go stdlib
     - exhaustivestruct  # replaced by exhaustruct
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,14 +3,6 @@ run:
 linters-settings:
   errcheck:
     check-type-assertions: true
-  exhaustruct:
-    include:
-      # No zero values for param structs.
-      - 'github\.com/bufbuild/connect-go\..*[pP]arams'
-      # No zero values for ClientStream, ServerStream, and friends.
-      - 'github\.com/bufbuild/connect-go\.ClientStream.*'
-      - 'github\.com/bufbuild/connect-go\.ServerStream.*'
-      - 'github\.com/bufbuild/connect-go\.BidiStream.*'
   forbidigo:
     forbid:
       - '^fmt\.Print'
@@ -24,11 +16,6 @@ linters-settings:
     keywords: [FIXME]
   importas:
     no-unaliased: true
-    alias:
-      - pkg: github.com/bufbuild/connect-go
-        alias: connect
-      - pkg: github.com/bufbuild/connect-go/internal/gen/connect/ping/v1
-        alias: pingv1
   varnamelen:
     ignore-decls:
       - T any
@@ -65,60 +52,3 @@ issues:
     # Don't ban use of fmt.Errorf to create new errors, but the remaining
     # checks from err113 are useful.
     - "err113: do not define dynamic errors.*"
-
-  exclude-rules:
-    # If future reflect.Kinds are nil-able, we'll find out when a test fails.
-    - linters: [exhaustive]
-      path: internal/assert/assert.go
-    # We need our duplex HTTP call to have access to the context.
-    - linters: [containedctx]
-      path: duplex_http_call.go
-    # We need to init a global in-mem HTTP server for testable examples.
-    - linters: [gochecknoinits, gochecknoglobals]
-      path: example_init_test.go
-    # We need to initialize a global map from a slice.
-    - linters: [gochecknoinits, gochecknoglobals]
-      path: protocol_grpc.go
-    # We purposefully do an ineffectual assignment for an example.
-    - linters: [ineffassign]
-      path: client_example_test.go
-    # The generated file is effectively a global receiver.
-    - linters: [varnamelen]
-      path: cmd/protoc-gen-connect-go
-      text: "parameter name 'g' is too short"
-    # Thorough error logging and timeout config make this example unreadably long.
-    - linters: [errcheck, gosec]
-      path: error_writer_example_test.go
-    # It should be crystal clear that Connect uses plain *http.Clients.
-    - linters: [revive, stylecheck]
-      path: client_example_test.go
-    # Don't complain about timeout management or lack of output assertions in examples.
-    - linters: [gosec, testableexamples]
-      path: handler_example_test.go
-    # No output assertions needed for these examples.
-    - linters: [testableexamples]
-      path: error_writer_example_test.go
-    - linters: [testableexamples]
-      path: error_not_modified_example_test.go
-    - linters: [testableexamples]
-      path: error_example_test.go
-    # In examples, it's okay to use http.ListenAndServe.
-    - linters: [gosec]
-      path: error_not_modified_example_test.go
-    # There are many instances where we want to keep unused parameters
-    # as a matter of style or convention, for example when a context.Context
-    # is the first parameter, we choose to just globally ignore this.
-    - linters: [revive]
-      text: "^unused-parameter: "
-    # We want to return explicit nils in protocol_grpc.go
-    - linters: [revive]
-      text: "^if-return: "
-      path: protocol_grpc.go
-    # We want to return explicit nils in protocol_connect.go
-    - linters: [revive]
-      text: "^if-return: "
-      path: protocol_connect.go
-    # We want to return explicit nils in error_writer.go
-    - linters: [revive]
-      text: "^if-return: "
-      path: error_writer.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,62 +3,122 @@ run:
 linters-settings:
   errcheck:
     check-type-assertions: true
+  exhaustruct:
+    include:
+      # No zero values for param structs.
+      - 'github\.com/bufbuild/connect-go\..*[pP]arams'
+      # No zero values for ClientStream, ServerStream, and friends.
+      - 'github\.com/bufbuild/connect-go\.ClientStream.*'
+      - 'github\.com/bufbuild/connect-go\.ServerStream.*'
+      - 'github\.com/bufbuild/connect-go\.BidiStream.*'
   forbidigo:
     forbid:
       - '^fmt\.Print'
       - '^log\.'
       - '^print$'
       - '^println$'
+      - '^panic$'
+  godox:
+    # TODO, OPT, etc. comments are fine to commit. Use FIXME comments for
+    # temporary hacks, and use godox to prevent committing them.
+    keywords: [FIXME]
+  importas:
+    no-unaliased: true
+    alias:
+      - pkg: github.com/bufbuild/connect-go
+        alias: connect
+      - pkg: github.com/bufbuild/connect-go/internal/gen/connect/ping/v1
+        alias: pingv1
+  varnamelen:
+    ignore-decls:
+      - T any
+      - i int
+      - wg sync.WaitGroup
 linters:
-  enable:
-    - asciicheck
-    - bidichk
-    - bodyclose
-    - containedctx
-    - contextcheck
-    - decorder
-    # - depguard
-    - dogsled
-    - errcheck
-    - execinquery
-    - exportloopref
-    - forbidigo
-    - forcetypeassert
-    - gochecknoinits
-    - gofmt
-    - goheader
-    - goimports
-    - gomodguard
-    - goprintffuncname
-    - gosec
-    - gosimple
-    - gosmopolitan
-    - govet
-    - grouper
-    - importas
-    - inamedparam
-    - ineffassign
-    - interfacebloat
-    - logrlint
-    - makezero
-    - mirror
-    - misspell
-    - nakedret
-    - nilerr
-    - nolintlint
-    - nosprintfhostport
-    - perfsprint
-    - predeclared
-    - promlinter
-    - protogetter
-    - reassign
-    - rowserrcheck
-    - staticcheck
-    - stylecheck
-    - testifylint
-    - typecheck
-    - unconvert
-    - unused
-    - wastedassign
-    - whitespace
-  disable-all: true
+  enable-all: true
+  disable:
+    - cyclop            # covered by gocyclo
+    - deadcode          # abandoned
+    - exhaustivestruct  # replaced by exhaustruct
+    - funlen            # rely on code review to limit function length
+    - gocognit          # dubious "cognitive overhead" quantification
+    - gofumpt           # prefer standard gofmt
+    - goimports         # rely on gci instead
+    - golint            # deprecated by Go team
+    - gomnd             # some unnamed constants are okay
+    - ifshort           # deprecated by author
+    - interfacer        # deprecated by author
+    - ireturn           # "accept interfaces, return structs" isn't ironclad
+    - lll               # don't want hard limits for line length
+    - maintidx          # covered by gocyclo
+    - maligned          # readability trumps efficient struct packing
+    - nlreturn          # generous whitespace violates house style
+    - nosnakecase       # deprecated in https://github.com/golangci/golangci-lint/pull/3065
+    - scopelint         # deprecated by author
+    - structcheck       # abandoned
+    - testpackage       # internal tests are fine
+    - varcheck          # abandoned
+    - wrapcheck         # don't _always_ need to wrap errors
+    - wsl               # generous whitespace violates house style
+issues:
+  exclude:
+    # Don't ban use of fmt.Errorf to create new errors, but the remaining
+    # checks from err113 are useful.
+    - "err113: do not define dynamic errors.*"
+
+  exclude-rules:
+    # If future reflect.Kinds are nil-able, we'll find out when a test fails.
+    - linters: [exhaustive]
+      path: internal/assert/assert.go
+    # We need our duplex HTTP call to have access to the context.
+    - linters: [containedctx]
+      path: duplex_http_call.go
+    # We need to init a global in-mem HTTP server for testable examples.
+    - linters: [gochecknoinits, gochecknoglobals]
+      path: example_init_test.go
+    # We need to initialize a global map from a slice.
+    - linters: [gochecknoinits, gochecknoglobals]
+      path: protocol_grpc.go
+    # We purposefully do an ineffectual assignment for an example.
+    - linters: [ineffassign]
+      path: client_example_test.go
+    # The generated file is effectively a global receiver.
+    - linters: [varnamelen]
+      path: cmd/protoc-gen-connect-go
+      text: "parameter name 'g' is too short"
+    # Thorough error logging and timeout config make this example unreadably long.
+    - linters: [errcheck, gosec]
+      path: error_writer_example_test.go
+    # It should be crystal clear that Connect uses plain *http.Clients.
+    - linters: [revive, stylecheck]
+      path: client_example_test.go
+    # Don't complain about timeout management or lack of output assertions in examples.
+    - linters: [gosec, testableexamples]
+      path: handler_example_test.go
+    # No output assertions needed for these examples.
+    - linters: [testableexamples]
+      path: error_writer_example_test.go
+    - linters: [testableexamples]
+      path: error_not_modified_example_test.go
+    - linters: [testableexamples]
+      path: error_example_test.go
+    # In examples, it's okay to use http.ListenAndServe.
+    - linters: [gosec]
+      path: error_not_modified_example_test.go
+    # There are many instances where we want to keep unused parameters
+    # as a matter of style or convention, for example when a context.Context
+    # is the first parameter, we choose to just globally ignore this.
+    - linters: [revive]
+      text: "^unused-parameter: "
+    # We want to return explicit nils in protocol_grpc.go
+    - linters: [revive]
+      text: "^if-return: "
+      path: protocol_grpc.go
+    # We want to return explicit nils in protocol_connect.go
+    - linters: [revive]
+      text: "^if-return: "
+      path: protocol_connect.go
+    # We want to return explicit nils in error_writer.go
+    - linters: [revive]
+      text: "^if-return: "
+      path: error_writer.go

--- a/internal/foo/foo_test.go
+++ b/internal/foo/foo_test.go
@@ -21,5 +21,6 @@ import (
 )
 
 func TestBar(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, "bar", Bar())
 }

--- a/make/go/dep_golangci_lint.mk
+++ b/make/go/dep_golangci_lint.mk
@@ -7,9 +7,9 @@ $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://github.com/golangci/golangci-lint/releases 20230821 checked 20230828
+# https://github.com/golangci/golangci-lint/releases 20231025 checked 20231027
 # Check for new linters and add to .golangci.yml (even if commented out) when upgrading
-GOLANGCI_LINT_VERSION ?= v1.54.2
+GOLANGCI_LINT_VERSION ?= v1.55.1
 
 GOLANGCI_LINT := $(CACHE_VERSIONS)/golangci-lint/$(GOLANGCI_LINT_VERSION)
 $(GOLANGCI_LINT):

--- a/make/go/dep_golangci_lint.mk
+++ b/make/go/dep_golangci_lint.mk
@@ -8,7 +8,7 @@ $(call _assert_var,CACHE_BIN)
 
 # Settable
 # https://github.com/golangci/golangci-lint/releases 20231025 checked 20231027
-# Check for new linters and add to .golangci.yml (even if commented out) when upgrading
+# Contrast golangci-lint configuration with the one in https://github.com/connectrpc/connect-go/blob/main/.golangci.yml when upgrading
 GOLANGCI_LINT_VERSION ?= v1.55.1
 
 GOLANGCI_LINT := $(CACHE_VERSIONS)/golangci-lint/$(GOLANGCI_LINT_VERSION)


### PR DESCRIPTION
- Use latest release as of today: https://github.com/golangci/golangci-lint/releases/tag/v1.55.1
- Update golangci-lint configuration using `connect-go` as base