### PR TITLE
Add preupgradegodeps target

### DIFF
--- a/make/go/go.mk
+++ b/make/go/go.mk
@@ -58,11 +58,14 @@ ci:
 	@$(MAKE) lint
 	@$(MAKE) test
 
+.PHONY: preupgradegodeps
+preupgradegodeps::
+
 .PHONY: postupgradegodeps
 postupgradegodeps::
 
 .PHONY: upgradegodeps
-upgradegodeps:
+upgradegodeps: preupgradegodeps
 	rm -f go.mod go.sum
 	go mod init $(GO_MODULE)
 	go mod edit -go=$(GO_MOD_VERSION)


### PR DESCRIPTION
In a downstream project, there's some initial work we need to take place prior to `upgradegodeps`. Add a new target `preupgradegodeps` which a downstream project can override.