### PR TITLE
Avoid long argument lists

### DIFF
--- a/make/go/go.mk
+++ b/make/go/go.mk
@@ -84,7 +84,7 @@ godeps: deps
 .PHONY: gofmtmodtidy
 gofmtmodtidy:
 	@echo gofmt -s -w ALL_GO_FILES
-	@find . -name '*.go' -print0 | xargs -0 gofmt -s -w
+	@gofmt -s -w .
 	go mod tidy -v
 
 format:: gofmtmodtidy

--- a/make/go/go.mk
+++ b/make/go/go.mk
@@ -91,7 +91,7 @@ format:: gofmtmodtidy
 
 .PHONY: checknonolint
 checknonolint:
-	@if find . -name '*.go' -print0 | xargs -0 grep '//nolint'; then \
+	@if grep -r --include "*.go" '//nolint'; then \
 		echo '//nolint directives found, surface ignores in .golangci.yml instead' >&2; \
 		exit 1; \
 	fi

--- a/make/go/go.mk
+++ b/make/go/go.mk
@@ -84,14 +84,14 @@ godeps: deps
 .PHONY: gofmtmodtidy
 gofmtmodtidy:
 	@echo gofmt -s -w ALL_GO_FILES
-	@gofmt -s -w $(shell find . -name '*.go')
+	@find . -name '*.go' -print0 | xargs -0 gofmt -s -w
 	go mod tidy -v
 
 format:: gofmtmodtidy
 
 .PHONY: checknonolint
 checknonolint:
-	@if grep '//nolint' $(shell find . -name '*.go'); then \
+	@if find . -name '*.go' -print0 | xargs -0 grep '//nolint'; then \
 		echo '//nolint directives found, surface ignores in .golangci.yml instead' >&2; \
 		exit 1; \
 	fi


### PR DESCRIPTION
If the list of Go files exceeds 128 KiB, the `gofmtmodtidy` and `checknonolint` rules might fail due to long argument lists.