### PR TITLE
Allow use of nolint comments if linter configured

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,10 @@ linters-settings:
       - T any
       - i int
       - wg sync.WaitGroup
+  nolintlint:
+    allow-unused: false
+    require-explanation: true
+    require-specific: true
 linters:
   enable-all: true
   disable:

--- a/make/go/dep_yq.mk
+++ b/make/go/dep_yq.mk
@@ -1,3 +1,5 @@
+# Managed by makego. DO NOT EDIT.
+
 # Must be set
 $(call _assert_var,MAKEGO)
 $(call _conditional_include,$(MAKEGO)/base.mk)

--- a/make/go/dep_yq.mk
+++ b/make/go/dep_yq.mk
@@ -1,0 +1,40 @@
+# Must be set
+$(call _assert_var,MAKEGO)
+$(call _conditional_include,$(MAKEGO)/base.mk)
+$(call _assert_var,UNAME_OS)
+$(call _assert_var,UNAME_ARCH)
+$(call _assert_var,CACHE_VERSIONS)
+$(call _assert_var,CACHE_BIN)
+
+# Settable
+# https://github.com/mikefarah/yq/releases 20240225 checked 20240320
+YQ_VERSION ?= v4.42.1
+
+ifeq ($(UNAME_OS),Darwin)
+YQ_OS := darwin
+ifeq ($(UNAME_ARCH),x86_64)
+YQ_ARCH := amd64
+endif
+ifeq ($(UNAME_ARCH),arm64)
+YQ_ARCH := arm64
+endif
+endif
+
+ifeq ($(UNAME_ARCH),x86_64)
+ifeq ($(UNAME_OS),Linux)
+YQ_OS := linux
+YQ_ARCH := amd64
+endif
+endif
+
+YQ := $(CACHE_VERSIONS)/yq/$(YQ_VERSION)
+$(YQ):
+	@rm -f $(CACHE_BIN)/yq
+	@mkdir -p $(CACHE_BIN)
+	curl -sSL \
+		https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(YQ_OS)_$(YQ_ARCH) \
+		-o $(CACHE_BIN)/yq
+	chmod +x $(CACHE_BIN)/yq
+	@rm -rf $(dir $(YQ))
+	@mkdir -p $(dir $(YQ))
+	@touch $(YQ)

--- a/make/go/go.mk
+++ b/make/go/go.mk
@@ -91,7 +91,9 @@ format:: gofmtmodtidy
 
 .PHONY: checknonolint
 checknonolint:
-	@if grep -r --include "*.go" '//nolint'; then \
+	@if bash $(MAKEGO)/scripts/checknolintlint.bash; then \
+		echo 'golangci-lint nolintlint configured'; \
+	elif grep -r --include "*.go" '//nolint'; then \
 		echo '//nolint directives found, surface ignores in .golangci.yml instead' >&2; \
 		exit 1; \
 	fi

--- a/make/go/go.mk
+++ b/make/go/go.mk
@@ -4,6 +4,7 @@
 $(call _assert_var,MAKEGO)
 $(call _conditional_include,$(MAKEGO)/base.mk)
 $(call _conditional_include,$(MAKEGO)/dep_golangci_lint.mk)
+$(call _conditional_include,$(MAKEGO)/dep_yq.mk)
 # Must be set
 $(call _assert_var,GO_MODULE)
 $(call _assert_var,GOLANGCI_LINT)
@@ -90,7 +91,7 @@ gofmtmodtidy:
 format:: gofmtmodtidy
 
 .PHONY: checknonolint
-checknonolint:
+checknonolint: $(YQ)
 	@if bash $(MAKEGO)/scripts/checknolintlint.bash; then \
 		echo 'golangci-lint nolintlint configured'; \
 	elif grep -r --include "*.go" '//nolint'; then \

--- a/make/go/go.mk
+++ b/make/go/go.mk
@@ -93,7 +93,7 @@ format:: gofmtmodtidy
 .PHONY: checknonolint
 checknonolint: $(YQ)
 	@if bash $(MAKEGO)/scripts/checknolintlint.bash; then \
-		echo 'golangci-lint nolintlint configured'; \
+		echo 'golangci-lint nolintlint configured' >&2; \
 	elif grep -r --include "*.go" '//nolint'; then \
 		echo '//nolint directives found, surface ignores in .golangci.yml instead' >&2; \
 		exit 1; \

--- a/make/go/scripts/checknolintlint.bash
+++ b/make/go/scripts/checknolintlint.bash
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Managed by makego. DO NOT EDIT.
+
+## checknolintlint exits with an exit code of 0 if nolintlint is enabled and configured properly.
+## It exits with an exit code of 2 if nolintlint is not enabled in .golangci.yml.
+## It exits with an exit code of 1 if nolintlint is not configured according to standards.
+
+set -euo pipefail
+
+# Check if nonolint linter is enabled in config
+NOLINTLINT_ENABLED=0
+if yq '.linters.enable // [] | any_c(. == "nolintlint")' .golangci.yml > /dev/null 2>&1; then
+    # Enabled individually
+    NOLINTLINT_ENABLED=1
+elif yq --exit-status '.linters.enable-all' .golangci.yml > /dev/null 2>&1; then
+    # Enabled with enable-all
+    NOLINTLINT_ENABLED=1
+fi
+if [ "${NOLINTLINT_ENABLED}" -eq 1 ]; then
+    # Ensure it isn't disabled individually
+    if yq --exit-status '.linters.disable // [] | any_c(. == "nolintlint")' .golangci.yml > /dev/null 2>&1; then
+        NOLINTLINT_ENABLED=0
+        echo "disabled individually" >&2
+    fi
+fi
+if [ "${NOLINTLINT_ENABLED}" -eq 0 ]; then
+    echo "not enabled" >&2
+    exit 2
+fi
+
+# Check if nolintlint is configured according to standards.
+#
+#   linters-settings:
+#     nolintlint:
+#       allow-unused: false
+#       allow-no-explanation: []
+#       require-explanation: true
+#       require-specific: true
+#
+
+if [[ `yq '.linters-settings.nolintlint.allow-unused // false' .golangci.yml` != "false" ]]; then
+    echo ".golangci.yml: nolintlint allow-unused must be set to false" >&2
+    exit 1
+fi
+if [[ `yq '.linters-settings.nolintlint.require-explanation // false' .golangci.yml` != "true" ]]; then
+    echo ".golangci.yml: nolintlint require-explanation must be set to true" >&2
+    exit 1
+fi
+if [[ `yq '.linters-settings.nolintlint.require-specific // false' .golangci.yml` != "true" ]]; then
+    echo ".golangci.yml: nolintlint require-specific must be set to true" >&2
+    exit 1
+fi
+if [[ `yq '.linters-settings.nolintlint.allow-no-explanation // [] | length' .golangci.yml` != "0" ]]; then
+    echo ".golangci.yml: nolintlint allow-no-explanation must be empty" >&2
+    exit 1
+fi
+exit 0

--- a/make/go/scripts/checknolintlint.bash
+++ b/make/go/scripts/checknolintlint.bash
@@ -37,7 +37,12 @@ fi
 #       require-specific: true
 #
 
-declare allow_unused= require_explanation= require_specific= allow_no_explanation_0=
+# These values will be set below by the yq command (if set in the file).
+allow_unused=
+require_explanation=
+require_specific=
+allow_no_explanation_0=
+
 eval $(yq --output-format shell '.linters-settings.nolintlint' .golangci.yml)
 if [[ "${allow_unused}" != "false" ]]; then
     echo ".golangci.yml: nolintlint allow-unused must be set to false" >&2

--- a/make/go/scripts/checknolintlint.bash
+++ b/make/go/scripts/checknolintlint.bash
@@ -10,22 +10,20 @@ set -euo pipefail
 
 # Check if nonolint linter is enabled in config
 NOLINTLINT_ENABLED=0
-if yq '.linters.enable // [] | any_c(. == "nolintlint")' .golangci.yml > /dev/null 2>&1; then
+if [[ `yq '.linters.enable // [] | any_c(. == "nolintlint")' .golangci.yml` == "true" ]]; then
     # Enabled individually
     NOLINTLINT_ENABLED=1
-elif yq --exit-status '.linters.enable-all' .golangci.yml > /dev/null 2>&1; then
+elif [[ `yq '.linters.enable-all' .golangci.yml` == "true" ]]; then
     # Enabled with enable-all
     NOLINTLINT_ENABLED=1
 fi
 if [ "${NOLINTLINT_ENABLED}" -eq 1 ]; then
     # Ensure it isn't disabled individually
-    if yq --exit-status '.linters.disable // [] | any_c(. == "nolintlint")' .golangci.yml > /dev/null 2>&1; then
+    if [[ `yq '.linters.disable // [] | any_c(. == "nolintlint")' .golangci.yml` == "true" ]]; then
         NOLINTLINT_ENABLED=0
-        echo "disabled individually" >&2
     fi
 fi
 if [ "${NOLINTLINT_ENABLED}" -eq 0 ]; then
-    echo "not enabled" >&2
     exit 2
 fi
 

--- a/make/go/scripts/checknolintlint.bash
+++ b/make/go/scripts/checknolintlint.bash
@@ -37,19 +37,21 @@ fi
 #       require-specific: true
 #
 
-if [[ `yq '.linters-settings.nolintlint.allow-unused // false' .golangci.yml` != "false" ]]; then
+declare allow_unused= require_explanation= require_specific= allow_no_explanation_0=
+eval $(yq --output-format shell '.linters-settings.nolintlint' .golangci.yml)
+if [[ "${allow_unused}" != "false" ]]; then
     echo ".golangci.yml: nolintlint allow-unused must be set to false" >&2
     exit 1
 fi
-if [[ `yq '.linters-settings.nolintlint.require-explanation // false' .golangci.yml` != "true" ]]; then
+if [[ "${require_explanation}" != "true" ]]; then
     echo ".golangci.yml: nolintlint require-explanation must be set to true" >&2
     exit 1
 fi
-if [[ `yq '.linters-settings.nolintlint.require-specific // false' .golangci.yml` != "true" ]]; then
+if [[ "${require_specific}" != "true" ]]; then
     echo ".golangci.yml: nolintlint require-specific must be set to true" >&2
     exit 1
 fi
-if [[ `yq '.linters-settings.nolintlint.allow-no-explanation // [] | length' .golangci.yml` != "0" ]]; then
+if [[ -n "${allow_no_explanation_0}" ]]; then
     echo ".golangci.yml: nolintlint allow-no-explanation must be empty" >&2
     exit 1
 fi

--- a/make/go/scripts/checknolintlint.bash
+++ b/make/go/scripts/checknolintlint.bash
@@ -2,13 +2,17 @@
 
 # Managed by makego. DO NOT EDIT.
 
-## checknolintlint exits with an exit code of 0 if nolintlint is enabled and configured properly.
-## It exits with an exit code of 2 if nolintlint is not enabled in .golangci.yml.
-## It exits with an exit code of 1 if nolintlint is not configured according to standards.
+## checknolintlint exits with exit code 0 if nolintlint is enabled and configured according to standards.
+## Otherwise, it exits with exit code 1.
 
 set -euo pipefail
 
-# Check if nonolint linter is enabled in config
+if [[ ! -f .golangci.yml ]]; then
+    echo "nolintlint not enabled in .golangci.yml" >&2
+    exit 1
+fiq
+
+# Check if nolintlint linter is enabled in config
 NOLINTLINT_ENABLED=0
 if [[ `yq '.linters.enable // [] | any_c(. == "nolintlint")' .golangci.yml` == "true" ]]; then
     # Enabled individually
@@ -24,7 +28,8 @@ if [ "${NOLINTLINT_ENABLED}" -eq 1 ]; then
     fi
 fi
 if [ "${NOLINTLINT_ENABLED}" -eq 0 ]; then
-    exit 2
+    echo "nolintlint not enabled in .golangci.yml" >&2
+    exit 1
 fi
 
 # Check if nolintlint is configured according to standards.
@@ -60,4 +65,3 @@ if [[ -n "${allow_no_explanation_0}" ]]; then
     echo ".golangci.yml: nolintlint allow-no-explanation must be empty" >&2
     exit 1
 fi
-exit 0


### PR DESCRIPTION
Some projects prefer using `//nolint` comments instead of configuring exclusions in the config file. These have the benefit of only disabling the selected linters at the specific place in the code and not across the entire file, they are automatically cleaned up when they no longer apply with `allow-unused: false`, and we can continue to require explanations at call sites alongside the code failing the lint check.

Update makego to call a bash script `checknolintlint.bash` to verify that the `nolintlint` linter is enabled and has the standard config. If this script passes, then allow for `//nolint` comments to be used in the source code. If not, continue using the existing `//nolint` detection to fail the build if comments are used.