### PR TITLE
Rebuild golangci-lint when go version changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/makego
 
-go 1.20
+go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
@@ -9,7 +9,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/make/go/dep_golangci_lint.mk
+++ b/make/go/dep_golangci_lint.mk
@@ -3,15 +3,20 @@
 # Must be set
 $(call _assert_var,MAKEGO)
 $(call _conditional_include,$(MAKEGO)/base.mk)
+$(call _conditional_include,$(MAKEGO)/dep_jq.mk)
 $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
-# Settable
-# https://github.com/golangci/golangci-lint/releases 20240813 checked 20240813
-# Contrast golangci-lint configuration with the one in https://github.com/connectrpc/connect-go/blob/main/.golangci.yml when upgrading
-GOLANGCI_LINT_VERSION ?= v1.60.0
+# We want to ensure we rebuild golangci-lint every time we require a new Go minor version.
+# Otherwise, the cached version may not support the latest language features.
+GOLANGCI_LINT_GO_VERSION := $(shell go mod edit -json | jq -r .Go | cut -d'.' -f1-2)
 
-GOLANGCI_LINT := $(CACHE_VERSIONS)/golangci-lint/$(GOLANGCI_LINT_VERSION)
+# Settable
+# https://github.com/golangci/golangci-lint/releases 20240813 checked 20240815
+# Contrast golangci-lint configuration with the one in https://github.com/connectrpc/connect-go/blob/main/.golangci.yml when upgrading
+GOLANGCI_LINT_VERSION ?= v1.60.1
+
+GOLANGCI_LINT := $(CACHE_VERSIONS)/golangci-lint/$(GOLANGCI_LINT_VERSION)-go$(GOLANGCI_LINT_GO_VERSION)
 $(GOLANGCI_LINT):
 	@rm -f $(CACHE_BIN)/golangci-lint
 	GOBIN=$(CACHE_BIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)


### PR DESCRIPTION
If the project upgrades the version of Go to a new minor (or major) release but doesn't rebuild golangci-lint with that version of Go, it is possible that certain language features won't be available until it is rebuilt.

For example, if golangci-lint is built with Go 1.21, it won't be able to lint code that uses the new range over integers syntax introduced in Go 1.22.

Update dep_golangci_lint.mk to add the major and minor version of Go to the cache key so that it will rebuild golangci-lint automatically if the Go major or minor version are updated in go.mod.