### PR TITLE
Update go and golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,7 @@ linters:
     - cyclop            # covered by gocyclo
     - depguard          # newer versions require explicit config to depend on anything outside of the Go stdlib
     - execinquery       # deprecated by author
+    - exportloopref     # deprecated in golangci v1.60.2
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/makego
 
-go 1.21
+go 1.22
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/make/go/dep_golangci_lint.mk
+++ b/make/go/dep_golangci_lint.mk
@@ -12,9 +12,9 @@ $(call _assert_var,CACHE_BIN)
 GOLANGCI_LINT_GO_VERSION := $(shell go mod edit -json | jq -r .Go | cut -d'.' -f1-2)
 
 # Settable
-# https://github.com/golangci/golangci-lint/releases 20240813 checked 20240815
+# https://github.com/golangci/golangci-lint/releases 20240822 checked 20240830
 # Contrast golangci-lint configuration with the one in https://github.com/connectrpc/connect-go/blob/main/.golangci.yml when upgrading
-GOLANGCI_LINT_VERSION ?= v1.60.1
+GOLANGCI_LINT_VERSION ?= v1.60.3
 
 GOLANGCI_LINT := $(CACHE_VERSIONS)/golangci-lint/$(GOLANGCI_LINT_VERSION)-go$(GOLANGCI_LINT_GO_VERSION)
 $(GOLANGCI_LINT):


### PR DESCRIPTION
This updates the min Go version to v1.22.0 and the version of golangci-lint to latest (v1.60.3)