### PR TITLE
Use unreleased version of protoc for custom check plugins

### DIFF
--- a/internal/gen/proto/go/org/foo/v1/foo.pb.go
+++ b/internal/gen/proto/go/org/foo/v1/foo.pb.go
@@ -44,9 +44,11 @@ type Bar struct {
 
 func (x *Bar) Reset() {
 	*x = Bar{}
-	mi := &file_org_foo_v1_foo_proto_msgTypes[0]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
+	if protoimpl.UnsafeEnabled {
+		mi := &file_org_foo_v1_foo_proto_msgTypes[0]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
 }
 
 func (x *Bar) String() string {
@@ -57,7 +59,7 @@ func (*Bar) ProtoMessage() {}
 
 func (x *Bar) ProtoReflect() protoreflect.Message {
 	mi := &file_org_foo_v1_foo_proto_msgTypes[0]
-	if x != nil {
+	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
 			ms.StoreMessageInfo(mi)
@@ -127,6 +129,20 @@ func init() { file_org_foo_v1_foo_proto_init() }
 func file_org_foo_v1_foo_proto_init() {
 	if File_org_foo_v1_foo_proto != nil {
 		return
+	}
+	if !protoimpl.UnsafeEnabled {
+		file_org_foo_v1_foo_proto_msgTypes[0].Exporter = func(v any, i int) any {
+			switch v := v.(*Bar); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/make/go/dep_protoc_gen_go.mk
+++ b/make/go/dep_protoc_gen_go.mk
@@ -7,8 +7,10 @@ $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://github.com/protocolbuffers/protobuf-go/releases 20240906 checked 20240916
-PROTOC_GEN_GO_VERSION ?= v1.34.3-0.20240906163944-03df6c145d96
+# https://github.com/protocolbuffers/protobuf-go/releases 20240816 checked 20240904
+# TODO: Change back to released version once bug is fixed
+PROTOC_GEN_GO_VERSION ?= 94ecbc26168965a670a0f7cf86f658131c790a9c
+
 
 GO_GET_PKGS := $(GO_GET_PKGS) \
 	google.golang.org/protobuf/proto@$(PROTOC_GEN_GO_VERSION)


### PR DESCRIPTION
This change https://github.com/protocolbuffers/protobuf-go/blob/94ecbc26168965a670a0f7cf86f658131c790a9c/reflect/protodesc/desc_init.go#L218-L220 was pulled in
to support custom lint/breaking plugins, so updating `makego` to reflect this change from `bufbuild/buf`.