### PR TITLE
Fix Makefiles to work with Linux on Apple Silicon

### DIFF
--- a/make/go/dep_jq.mk
+++ b/make/go/dep_jq.mk
@@ -14,19 +14,16 @@ JQ_VERSION ?= 1.7.1
 
 ifeq ($(UNAME_OS),Darwin)
 JQ_OS := macos
-ifeq ($(UNAME_ARCH),x86_64)
-JQ_ARCH := amd64
-else
-JQ_ARCH := $(UNAME_ARCH)
-endif
+else ifeq ($(UNAME_OS),Linux)
+JQ_OS := linux
 endif
 
 ifeq ($(UNAME_ARCH),x86_64)
-ifeq ($(UNAME_OS),Linux)
-JQ_OS := linux
 JQ_ARCH := amd64
+else
+JQ_ARCH := $(UNAME_OS)
 endif
-endif
+
 JQ := $(CACHE_VERSIONS)/jq/$(JQ_VERSION)
 $(JQ):
 	@rm -f $(CACHE_BIN)/jq

--- a/make/go/dep_yq.mk
+++ b/make/go/dep_yq.mk
@@ -14,20 +14,20 @@ YQ_VERSION ?= v4.44.1
 
 ifeq ($(UNAME_OS),Darwin)
 YQ_OS := darwin
-ifeq ($(UNAME_ARCH),x86_64)
-YQ_ARCH := amd64
-endif
-ifeq ($(UNAME_ARCH),arm64)
-YQ_ARCH := arm64
-endif
+else ifeq ($(UNAME_OS),Linux)
+YQ_OS := linux
 endif
 
 ifeq ($(UNAME_ARCH),x86_64)
-ifeq ($(UNAME_OS),Linux)
-YQ_OS := linux
 YQ_ARCH := amd64
+else ifeq ($(UNAME_ARCH),arm64)
+YQ_ARCH := arm64
+else ifeq ($(UNAME_ARCH),aarch64)
+YQ_ARCH := arm64
+else
+YQ_ARCH := $(UNAME_ARCH)
 endif
-endif
+
 
 YQ := $(CACHE_VERSIONS)/yq/$(YQ_VERSION)
 $(YQ):


### PR DESCRIPTION
This Updates the project's Makefiles to ensure compatibility with Linux running on Apple Silicon (ARM architecture).