### PR TITLE
Bump golangci-lint version

### DIFF
--- a/make/go/dep_golangci_lint.mk
+++ b/make/go/dep_golangci_lint.mk
@@ -12,9 +12,9 @@ $(call _assert_var,CACHE_BIN)
 GOLANGCI_LINT_GO_VERSION := $(shell go mod edit -json | jq -r .Go | cut -d'.' -f1-2)
 
 # Settable
-# https://github.com/golangci/golangci-lint/releases 20240909 checked 20240916
+# https://github.com/golangci/golangci-lint/releases 20241110 checked 20241113
 # Contrast golangci-lint configuration with the one in https://github.com/connectrpc/connect-go/blob/main/.golangci.yml when upgrading
-GOLANGCI_LINT_VERSION ?= v1.61.0
+GOLANGCI_LINT_VERSION ?= v1.62.0
 
 GOLANGCI_LINT := $(CACHE_VERSIONS)/golangci-lint/$(GOLANGCI_LINT_VERSION)-go$(GOLANGCI_LINT_GO_VERSION)
 $(GOLANGCI_LINT):


### PR DESCRIPTION
Ref: https://github.com/golangci/golangci-lint/releases/tag/v1.62.0