### PR TITLE
Remove token from CLI version update workflow

### DIFF
--- a/.github/workflows/update-buf-version.yaml
+++ b/.github/workflows/update-buf-version.yaml
@@ -23,8 +23,6 @@ jobs:
           exit 1
       - name: Checkout repository code
         uses: actions/checkout@v4
-        with:
-          token: ${{ steps.app_token.outputs.token }}
       - name: Update Buf Version
         run: make updatebufversion
       - name: Create PR


### PR DESCRIPTION
The token is not required (or provided) for the checkout step
of the CLI version update workflow.