### PR TITLE
Upgrade connectrpc v1.18.0

### DIFF
--- a/make/go/dep_protoc_gen_connect_go.mk
+++ b/make/go/dep_protoc_gen_connect_go.mk
@@ -8,7 +8,7 @@ $(call _assert_var,CACHE_BIN)
 
 # Settable
 # https://github.com/connectrpc/connect-go 20240920 checked 20240920
-CONNECT_VERSION ?= v1.17.0
+CONNECT_VERSION ?= v1.18.0
 
 GO_GET_PKGS := $(GO_GET_PKGS) \
 	connectrpc.com/connect@$(CONNECT_VERSION)

--- a/make/go/dep_protoc_gen_connect_go.mk
+++ b/make/go/dep_protoc_gen_connect_go.mk
@@ -7,7 +7,7 @@ $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://github.com/connectrpc/connect-go 20240920 checked 20240920
+# https://github.com/connectrpc/connect-go 20250107 checked 20250108
 CONNECT_VERSION ?= v1.18.0
 
 GO_GET_PKGS := $(GO_GET_PKGS) \


### PR DESCRIPTION
There is a fix for the generated code in v1.18.1. Most generated code won't be affected, so can upgrade to v1.18.0 with v1.18.1 as a fast follow.