### PR TITLE
Upgrade protoc to 29.3

### DIFF
--- a/make/go/dep_protoc.mk
+++ b/make/go/dep_protoc.mk
@@ -10,9 +10,9 @@ $(call _assert_var,CACHE_INCLUDE)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://github.com/protocolbuffers/protobuf/releases 20241204 checked 20241217
+# https://github.com/protocolbuffers/protobuf/releases 20250108 checked 20250115
 # NOTE: Set to version compatible with genproto source code (only used in tests).
-PROTOC_VERSION ?= 29.1
+PROTOC_VERSION ?= 29.3
 
 # Google adds a dash to release candidate versions in the name of the
 # release artifact, i.e. v27.0-rc1 -> v27.0-rc-1


### PR DESCRIPTION
Upgrade protoc: https://github.com/protocolbuffers/protobuf/releases/tag/v29.3

This will be used for WKT to pull in `go_features.proto` that include all the latest changes.