### PR TITLE
Bump dep_protoc to latest version

### DIFF
--- a/make/go/dep_protoc.mk
+++ b/make/go/dep_protoc.mk
@@ -10,9 +10,9 @@ $(call _assert_var,CACHE_INCLUDE)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://github.com/protocolbuffers/protobuf/releases 20250528 checked 20250603
+# https://github.com/protocolbuffers/protobuf/releases 20260319 checked 20260324
 # NOTE: Set to version compatible with genproto source code (only used in tests).
-PROTOC_VERSION ?= 31.1
+PROTOC_VERSION ?= 34.1
 
 # Google adds a dash to release candidate versions in the name of the
 # release artifact, i.e. v27.0-rc1 -> v27.0-rc-1


### PR DESCRIPTION
In bufbuild/buf#4383 I failed to notice that protoc was a makego dep; pulling in the latest via `copyfrommakego` in bufbuild/buf#4410 is reverting this change. May as well bump to latest.

Ref: https://github.com/protocolbuffers/protobuf/releases