### PR TITLE
Downgrade PROTOC_VERSION to 33.2

### DIFF
--- a/make/go/dep_protoc.mk
+++ b/make/go/dep_protoc.mk
@@ -10,10 +10,10 @@ $(call _assert_var,CACHE_INCLUDE)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://github.com/protocolbuffers/protobuf/releases 20260318 checked 20260427
+# https://github.com/protocolbuffers/protobuf/releases 20251205 checked 20260427
 # NOTE: Set to version compatible with genproto source code (only used in tests).
 # This version must be supported by the matching https://github.com/protocolbuffers/protobuf-go version.
-PROTOC_VERSION ?= 33.6
+PROTOC_VERSION ?= 33.2
 
 # Google adds a dash to release candidate versions in the name of the
 # release artifact, i.e. v27.0-rc1 -> v27.0-rc-1

--- a/make/go/dep_protoc.mk
+++ b/make/go/dep_protoc.mk
@@ -10,9 +10,10 @@ $(call _assert_var,CACHE_INCLUDE)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://github.com/protocolbuffers/protobuf/releases 20260319 checked 20260324
+# https://github.com/protocolbuffers/protobuf/releases 20260318 checked 20260427
 # NOTE: Set to version compatible with genproto source code (only used in tests).
-PROTOC_VERSION ?= 34.1
+# This version must be supported by the matching https://github.com/protocolbuffers/protobuf-go version.
+PROTOC_VERSION ?= 33.6
 
 # Google adds a dash to release candidate versions in the name of the
 # release artifact, i.e. v27.0-rc1 -> v27.0-rc-1


### PR DESCRIPTION
This is the latest that latest version of protobuf-go understands.

Ref: https://github.com/protocolbuffers/protobuf-go/releases/tag/v1.36.11