### PR TITLE
Use make for basic string handling

### DIFF
--- a/make/go/bootstrap.mk
+++ b/make/go/bootstrap.mk
@@ -14,3 +14,7 @@ endef
 define _conditional_include
 	$(if $(filter $(1),$(MAKEFILE_LIST)),,$(eval include $(1)))
 endef
+# Extracts the major.minor (e.g. 1.26) from a dotted version string (e.g. 1.26.3).
+define _major_minor
+$(word 1,$(subst ., ,$(1))).$(word 2,$(subst ., ,$(1)))
+endef

--- a/make/go/dep_bufstyle.mk
+++ b/make/go/dep_bufstyle.mk
@@ -10,7 +10,7 @@ $(call _assert_var,BUF_VERSION)
 
 # We want to ensure we rebuild bufstyle every time we require a new Go minor version.
 # Otherwise, the cached version may not support the latest language features.
-BUFSTYLE_GO_VERSION := $(shell go list -m -f '{{.GoVersion}}' | cut -d'.' -f1-2)
+BUFSTYLE_GO_VERSION := $(call _major_minor,$(shell go list -m -f '{{.GoVersion}}'))
 
 # Settable
 # https://github.com/bufbuild/bufstyle-go/releases

--- a/make/go/dep_godoclint.mk
+++ b/make/go/dep_godoclint.mk
@@ -12,8 +12,8 @@ $(call _assert_var,BUF_VERSION)
 # Otherwise, the cached version may not support the latest language features.
 # This version is the go toolchain version (which may be more specific than the module
 # version) to ensure the build handles specific language features in newer toolchains.
-GODOCLINT_GOTOOLCHAIN_VERSION := $(shell go env GOVERSION | sed 's/^go//')
-GODOCLINT_GO_VERSION := $(shell echo $(GODOCLINT_GOTOOLCHAIN_VERSION) | cut -d'.' -f1-2)
+GODOCLINT_GOTOOLCHAIN_VERSION := $(patsubst go%,%,$(shell go env GOVERSION))
+GODOCLINT_GO_VERSION := $(call _major_minor,$(GODOCLINT_GOTOOLCHAIN_VERSION))
 
 # Settable
 #

--- a/make/go/dep_govulncheck.mk
+++ b/make/go/dep_govulncheck.mk
@@ -10,8 +10,8 @@ $(call _assert_var,CACHE_BIN)
 # Otherwise, the cached version may not support the latest language features.
 # This version is the go toolchain version (which may be more specific than the module
 # version) to ensure the build handles specific language features in newer toolchains.
-GOVULNCHECK_GOTOOLCHAIN_VERSION := $(shell go env GOVERSION | sed 's/^go//')
-GOVULNCHECK_GO_VERSION := $(shell echo $(GOVULNCHECK_GOTOOLCHAIN_VERSION) | cut -d'.' -f1-2)
+GOVULNCHECK_GOTOOLCHAIN_VERSION := $(patsubst go%,%,$(shell go env GOVERSION))
+GOVULNCHECK_GO_VERSION := $(call _major_minor,$(GOVULNCHECK_GOTOOLCHAIN_VERSION))
 
 # Settable
 # https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck 20260410 checked 20260422


### PR DESCRIPTION
Update a few places that are piping strings to separate tools to use make builtin string handling instead. This should be faster and also avoid external tool dependencies.