### PR TITLE
Add preupgradegodeps hook

### DIFF
--- a/make/go/go.mk
+++ b/make/go/go.mk
@@ -87,6 +87,9 @@ ci:
 	@$(MAKE) lint
 	@$(MAKE) test
 
+.PHONY: preupgradegodeps
+preupgradegodeps::
+
 .PHONY: postupgradegodeps
 postupgradegodeps::
 
@@ -98,6 +101,7 @@ upgradegodeps:
 ifneq ($(GO_MOD_TOOLCHAIN),)
 	go mod edit -toolchain=go$(GO_MOD_TOOLCHAIN)
 endif
+	@$(MAKE) preupgradegodeps
 ifneq ($(GO_GET_PKGS),)
 	go get $(GO_GET_PKGS)
 endif


### PR DESCRIPTION
A downstream project needs to add some dependencies prior to running `go get -u -t`. Add a preupgradegodeps hook to allow downstream projects to customize behavior.