### PR TITLE
Cache generators by Go version

### DIFF
--- a/make/go/base.mk
+++ b/make/go/base.mk
@@ -12,6 +12,11 @@ $(call _assert_var,GO_MODULE)
 UNAME_OS := $(shell uname -s)
 UNAME_ARCH := $(shell uname -m)
 
+# The version of the Go toolchain in use, e.g. 1.27.0. This is the toolchain that builds the
+# binaries in the cache, as opposed to GO_MOD_VERSION, which is the version written to the
+# go directive in go.mod.
+GO_VERSION := $(patsubst go%,%,$(lastword $(shell go env GOVERSION)))
+
 ENV_DIR := .env
 ENV_SH := $(ENV_DIR)/env.sh
 ENV_BACKUP_DIR := $(HOME)/.config/$(PROJECT)/env

--- a/make/go/dep_protoc_gen_go.mk
+++ b/make/go/dep_protoc_gen_go.mk
@@ -5,6 +5,7 @@ $(call _assert_var,MAKEGO)
 $(call _conditional_include,$(MAKEGO)/base.mk)
 $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
+$(call _assert_var,GO_VERSION)
 
 # Settable
 # https://github.com/protocolbuffers/protobuf-go/releases 20260810 checked 20260813
@@ -15,7 +16,10 @@ GO_GET_PKGS := $(GO_GET_PKGS) \
 
 PROTOC_GEN_GO := $(CACHE_BIN)/protoc-gen-go
 
-$(CACHE_VERSIONS)/protoc-gen-go/protoc-gen-go-$(PROTOC_GEN_GO_VERSION):
+# The cache key includes GO_VERSION: protoc-gen-go formats its output with go/format, so
+# the code it generates depends on the toolchain that built it, and we want to rebuild the
+# plugin whenever that toolchain changes.
+$(CACHE_VERSIONS)/protoc-gen-go/protoc-gen-go-$(PROTOC_GEN_GO_VERSION)-go$(GO_VERSION):
 	@rm -f $(PROTOC_GEN_GO)
 	@rm -rf $(dir $@)
 	@mkdir -p $(dir $@)
@@ -24,7 +28,7 @@ $(CACHE_VERSIONS)/protoc-gen-go/protoc-gen-go-$(PROTOC_GEN_GO_VERSION):
 	@test -x $@
 	@touch $@
 
-$(PROTOC_GEN_GO): $(CACHE_VERSIONS)/protoc-gen-go/protoc-gen-go-$(PROTOC_GEN_GO_VERSION)
+$(PROTOC_GEN_GO): $(CACHE_VERSIONS)/protoc-gen-go/protoc-gen-go-$(PROTOC_GEN_GO_VERSION)-go$(GO_VERSION)
 	@mkdir -p $(dir $@)
 	@ln -sf $< $@
 


### PR DESCRIPTION
This adds the GO_VERSION (new build version var) to the cache key of protoc-gen-go. Getting build diffs due to local/remote differences in the generator build version, see https://github.com/bufbuild/buf/pull/4651#issuecomment-5372067097 as an example.

I think its this issue: https://github.com/golang/go/issues/52605