### PR TITLE
Cache protoc-gen-connect-go Go version

### DIFF
--- a/make/go/dep_protoc_gen_connect_go.mk
+++ b/make/go/dep_protoc_gen_connect_go.mk
@@ -15,7 +15,8 @@ GO_GET_PKGS := $(GO_GET_PKGS) \
 
 PROTOC_GEN_CONNECT_GO := $(CACHE_BIN)/protoc-gen-connect-go
 
-$(CACHE_VERSIONS)/connect-go/protoc-gen-connect-go-$(CONNECT_VERSION):
+# Keyed by GO_VERSION: the plugin formats its output with go/format
+$(CACHE_VERSIONS)/connect-go/protoc-gen-connect-go-$(CONNECT_VERSION)-go$(GO_VERSION):
 	@rm -f $(PROTOC_GEN_CONNECT_GO)
 	@rm -rf $(dir $@)
 	@mkdir -p $(dir $@)
@@ -24,7 +25,7 @@ $(CACHE_VERSIONS)/connect-go/protoc-gen-connect-go-$(CONNECT_VERSION):
 	@test -x $@
 	@touch $@
 
-$(PROTOC_GEN_CONNECT_GO): $(CACHE_VERSIONS)/connect-go/protoc-gen-connect-go-$(CONNECT_VERSION)
+$(PROTOC_GEN_CONNECT_GO): $(CACHE_VERSIONS)/connect-go/protoc-gen-connect-go-$(CONNECT_VERSION)-go$(GO_VERSION)
 	@mkdir -p $(dir $@)
 	@ln -sf $< $@
 

--- a/make/go/dep_protoc_gen_go.mk
+++ b/make/go/dep_protoc_gen_go.mk
@@ -16,9 +16,7 @@ GO_GET_PKGS := $(GO_GET_PKGS) \
 
 PROTOC_GEN_GO := $(CACHE_BIN)/protoc-gen-go
 
-# The cache key includes GO_VERSION: protoc-gen-go formats its output with go/format, so
-# the code it generates depends on the toolchain that built it, and we want to rebuild the
-# plugin whenever that toolchain changes.
+# Keyed by GO_VERSION: the plugin formats its output with go/format
 $(CACHE_VERSIONS)/protoc-gen-go/protoc-gen-go-$(PROTOC_GEN_GO_VERSION)-go$(GO_VERSION):
 	@rm -f $(PROTOC_GEN_GO)
 	@rm -rf $(dir $@)


### PR DESCRIPTION
Follow on from https://github.com/bufbuild/makego/pull/332. Missed protoc-gen-connect-go.